### PR TITLE
Don't use group for the file module. Otherwise environments without g…

### DIFF
--- a/tasks/write-config.yml
+++ b/tasks/write-config.yml
@@ -5,7 +5,6 @@
     path: '~{{ item.username }}/.atom'
     state: directory
     owner: '{{ item.username }}'
-    group: '{{ item.username }}'
     mode: 'u=rwx,go='
   with_items: '{{ users }}'
 
@@ -17,7 +16,6 @@
     force: '{{ item.atom_config_overwrite | default(False) }}'
     backup: '{{ item.atom_config_overwrite | default(False) }}'
     owner: '{{ item.username }}'
-    group: '{{ item.username }}'
     mode: 'u=rw,go='
   with_items: '{{ users }}'
   when: "item.atom_config is defined and item.atom_config not in ({}, '', None, omit)"


### PR DESCRIPTION
…roups named by the username will failed to write the config. If the group parameter is missing in the file module the default group from the user is used.