### PR TITLE
Don't set group with username. There are systems especially with LDAP…

### DIFF
--- a/tasks/write-config.yml
+++ b/tasks/write-config.yml
@@ -5,7 +5,6 @@
     path: '~{{ item.username }}/.atom'
     state: directory
     owner: '{{ item.username }}'
-    group: '{{ item.username }}'
     mode: 'u=rwx,go='
   with_items: '{{ users }}'
 
@@ -17,7 +16,6 @@
     force: '{{ item.atom_config_overwrite | default(False) }}'
     backup: '{{ item.atom_config_overwrite | default(False) }}'
     owner: '{{ item.username }}'
-    group: '{{ item.username }}'
     mode: 'u=rw,go='
   with_items: '{{ users }}'
   when: "item.atom_config is defined and item.atom_config not in ({}, '', None, omit)"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,6 @@ def test_config(File):
     assert config_file.exists
     assert config_file.is_file
     assert config_file.user == 'test_usr'
-    assert config_file.group == 'test_usr'
     assert oct(config_file.mode) == '0600'
     assert config_file.contains('"projectHome": "/home/vagrant/workspace"')
 
@@ -20,7 +19,6 @@ def test_perserve_config(File):
     assert config_file.exists
     assert config_file.is_file
     assert config_file.user == 'test_usr4'
-    assert config_file.group == 'test_usr4'
     assert oct(config_file.mode) == '0600'
     assert config_file.contains('Existing config')
 
@@ -31,7 +29,6 @@ def test_overwrite_config(Command, File):
     assert config_file.exists
     assert config_file.is_file
     assert config_file.user == 'test_usr5'
-    assert config_file.group == 'test_usr5'
     assert oct(config_file.mode) == '0600'
     assert config_file.contains('"projectHome": "/home/vagrant/workspace"')
 


### PR DESCRIPTION
Don't set group with username. There are systems especially with LDAP/AD groups where a group named by the username doesn't exist. Otherwise, the role in this condition will fail.