### PR TITLE
Use become_user to get the primary group when creating files or directories

### DIFF
--- a/tasks/write-config.yml
+++ b/tasks/write-config.yml
@@ -1,23 +1,23 @@
 ---
 - name: create config directory
   become: yes
+  become_user: '{{ item.username }}'
   file:
     path: '~{{ item.username }}/.atom'
     state: directory
     owner: '{{ item.username }}'
-    group: '{{ item.username }}'
     mode: 'u=rwx,go='
   with_items: '{{ users }}'
 
 - name: write config
   become: yes
+  become_user: '{{ item.username }}'
   template:
     src: config.cson.j2
     dest: '~{{ item.username }}/.atom/config.cson'
     force: '{{ item.atom_config_overwrite | default(False) }}'
     backup: '{{ item.atom_config_overwrite | default(False) }}'
     owner: '{{ item.username }}'
-    group: '{{ item.username }}'
     mode: 'u=rw,go='
   with_items: '{{ users }}'
   when: "item.atom_config is defined and item.atom_config not in ({}, '', None, omit)"


### PR DESCRIPTION
Use become_user to get the primary group when creating files or directories instead of setting the group directly by the username. This resolves problems on systems where no group named by the username exists.