### PR TITLE
Increased minimum Ansible version to 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python: '2.7'
 
 # Spin off separate builds for each of the following versions of Ansible
 env:
-  - ANSIBLE_VERSION=2.3.2
+  - ANSIBLE_VERSION=2.4.6
   - ANSIBLE_VERSION=2.6.3
 
 # Require the standard build environment

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Role to install the [atom.io](https://atom.io) text editor by GitHub.
 Requirements
 ------------
 
-* Ansible >= 2.3
+* Ansible >= 2.4
 * Ubuntu
 
 Role Variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing the atom.io editor.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
In preparation for resolving deprecated `include` warnings.