### PR TITLE
Resolved deprecation warning for include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
-- include: install.yml
+- import_tasks: install.yml
 
-- include: install-packages.yml
+- import_tasks: install-packages.yml
 
-- include: write-config.yml
+- import_tasks: write-config.yml


### PR DESCRIPTION
Since Ansible 2.4 `include` has been deprecated.

```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use
'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.
```