### PR TITLE
Changed tests to use host fixture

### DIFF
--- a/molecule/default/tests/test_config.py
+++ b/molecule/default/tests/test_config.py
@@ -6,8 +6,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_config(File):
-    config_file = File('/home/test_usr/.atom/config.cson')
+def test_config(host):
+    config_file = host.file('/home/test_usr/.atom/config.cson')
 
     assert config_file.exists
     assert config_file.is_file
@@ -17,8 +17,8 @@ def test_config(File):
     assert config_file.contains('"projectHome": "/home/vagrant/workspace"')
 
 
-def test_perserve_config(File):
-    config_file = File('/home/test_usr4/.atom/config.cson')
+def test_perserve_config(host):
+    config_file = host.file('/home/test_usr4/.atom/config.cson')
 
     assert config_file.exists
     assert config_file.is_file
@@ -28,8 +28,8 @@ def test_perserve_config(File):
     assert config_file.contains('Existing config')
 
 
-def test_overwrite_config(Command, File):
-    config_file = File('/home/test_usr5/.atom/config.cson')
+def test_overwrite_config(host):
+    config_file = host.file('/home/test_usr5/.atom/config.cson')
 
     assert config_file.exists
     assert config_file.is_file
@@ -38,10 +38,10 @@ def test_overwrite_config(Command, File):
     assert oct(config_file.mode) == '0600'
     assert config_file.contains('"projectHome": "/home/vagrant/workspace"')
 
-    backup_path = Command.check_output('find %s | grep --color=never -E %s',
-                                       '/home/test_usr5/.atom/',
-                                       '~$')
-    backup_file = File(backup_path)
+    backup_path = host.check_output('find %s | grep --color=never -E %s',
+                                    '/home/test_usr5/.atom/',
+                                    '~$')
+    backup_file = host.file(backup_path)
 
     assert backup_file.is_file
     assert oct(backup_file.mode) == '0600'

--- a/molecule/default/tests/test_install.py
+++ b/molecule/default/tests/test_install.py
@@ -6,9 +6,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_atom(Command):
-    assert Command('which atom').rc == 0
+def test_atom(host):
+    assert host.run('which atom').rc == 0
 
 
-def test_apm(Command):
-    assert Command('apm --version').rc == 0
+def test_apm(host):
+    assert host.run('apm --version').rc == 0

--- a/molecule/default/tests/test_packages.py
+++ b/molecule/default/tests/test_packages.py
@@ -11,6 +11,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     'minimap',
     'linter'
 ])
-def test_packages(Command, atom_package):
+def test_packages(host, atom_package):
     cmd = 'sudo --user test_usr -H apm list --bare | grep -E %s'
-    assert Command(cmd, '^' + atom_package + '@').rc == 0
+    assert host.run(cmd, '^' + atom_package + '@').rc == 0


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.