### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Ubuntu
 
-            * Xenial (16.04)
             * Bionic (18.04)
             * Focal (20.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
   galaxy_tags:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-atom-ubuntu-min
-    image: ubuntu:16.04
+    image: ubuntu:18.04
   - name: ansible-role-atom-ubuntu-max
     image: ubuntu:20.04
 


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Xenial.